### PR TITLE
fix unity build error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
     environment {
         UNITY_PROJECT_DIR='UnityProjectSample'
         IMAGE='unityci/editor'
-        UNITY_VERSION='2021.3.6f1-ios-1.0'
+        UNITY_VERSION='2020.2.4f1-ios-1.0'
         // Build parameters
         UNITY_LICENSE_FILE='UNITY_LICENSE_FILE'
         PROVISIONING_PROFILE_NAME='UnityBuildSample-profile'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,6 @@ pipeline {
     environment {
         UNITY_PROJECT_DIR='UnityProjectSample'
         IMAGE='unityci/editor'
-        UNITY_VERSION='2020.2.4f1-ios-1.0'
         // Build parameters
         UNITY_LICENSE_FILE='UNITY_LICENSE_FILE'
         PROVISIONING_PROFILE_NAME='UnityBuildSample-profile'
@@ -42,7 +41,7 @@ pipeline {
             agent {
 
                 docker {
-                    image 'unityci/editor:2021.3.6f1-ios-1.0'
+                    image 'unityci/editor:2020.2.4f1-ios-1.0'
                     args '-u root:root'
                 }
             }

--- a/UnityProjectSample/Assets/Editor/ExportTool.cs
+++ b/UnityProjectSample/Assets/Editor/ExportTool.cs
@@ -28,7 +28,9 @@ class ExportTool
 		PlayerSettings.applicationIdentifier = "com.evgeniik.samples.UnityBuildSample";
 		EditorUserBuildSettings.SwitchActiveBuildTarget (BuildTarget.iOS);
 
-		EditorUserBuildSettings.symlinkSources = true;
+		// not available in Unity 2020.2
+		// https://docs.unity3d.com/2020.2/Documentation/ScriptReference/EditorUserBuildSettings.html
+		// EditorUserBuildSettings.symlinkSources = true;
 		EditorUserBuildSettings.development = true;
 		EditorUserBuildSettings.allowDebugging = true;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* [Nodulus](https://github.com/Hyperparticle/nodulus), a sample Unity project used in this demo, uses Unity 2020.2.4f1. It seems versions must match because when I use other Unity docker image to build, it just fails.
* Because Unity 2020.2 does not support `EditorUserBuildSettings.symlinkSources` property, I just commented out the code.

As I tested this change only manually, I'd appreciate if you could test it in the actual configuration 🙏 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
